### PR TITLE
Fixed build on PHP >= 5.5

### DIFF
--- a/vld.c
+++ b/vld.c
@@ -43,8 +43,15 @@ static zend_op_array* vld_compile_file(zend_file_handle*, int TSRMLS_DC);
 static zend_op_array* (*old_compile_string)(zval *source_string, char *filename TSRMLS_DC);
 static zend_op_array* vld_compile_string(zval *source_string, char *filename TSRMLS_DC);
 
+#if PHP_VERSION_ID >= 50500
+static void (*old_execute)(zend_execute_data *execute_data TSRMLS_DC);
+static void vld_execute(zend_execute_data *execute_data TSRMLS_DC);
+#define vld_zend_execute_ptr zend_execute_ex
+#else
 static void (*old_execute)(zend_op_array *op_array TSRMLS_DC);
 static void vld_execute(zend_op_array *op_array TSRMLS_DC);
+#define vld_zend_execute_ptr zend_execute
+#endif
 
 
 zend_function_entry vld_functions[] = {
@@ -118,7 +125,7 @@ PHP_MSHUTDOWN_FUNCTION(vld)
 #if (PHP_MAJOR_VERSION > 5) || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 2)
 	zend_compile_string = old_compile_string;
 #endif
-	zend_execute        = old_execute;
+	vld_zend_execute_ptr = old_execute;
 
 	return SUCCESS;
 }
@@ -131,7 +138,7 @@ PHP_RINIT_FUNCTION(vld)
 #if (PHP_MAJOR_VERSION > 5) || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 2)
 	old_compile_string = zend_compile_string;
 #endif
-	old_execute = zend_execute;
+	old_execute = vld_zend_execute_ptr;
 
 	if (VLD_G(active)) {
 		zend_compile_file = vld_compile_file;
@@ -139,7 +146,11 @@ PHP_RINIT_FUNCTION(vld)
 		zend_compile_string = vld_compile_string;
 #endif
 		if (!VLD_G(execute)) {
+#if (PHP_MAJOR_VERSION > 5) || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 5)
+			zend_execute_ex = vld_execute;
+#else
 			zend_execute = vld_execute;
+#endif
 		}
 	}
 
@@ -164,7 +175,7 @@ PHP_RINIT_FUNCTION(vld)
 PHP_RSHUTDOWN_FUNCTION(vld)
 {
 	zend_compile_file = old_compile_file;
-	zend_execute      = old_execute;
+	vld_zend_execute_ptr = old_execute;
 
 	if (VLD_G(path_dump_file)) {
 		fprintf(VLD_G(path_dump_file), "}\n");
@@ -339,7 +350,11 @@ static zend_op_array *vld_compile_string(zval *source_string, char *filename TSR
 
 /* {{{ void vld_execute(zend_op_array *op_array TSRMLS_DC)
  *    This function provides a hook for execution */
+#if PHP_VERSION_ID >= 50500
+static void vld_execute(zend_execute_data *execute_data TSRMLS_DC)
+#else
 static void vld_execute(zend_op_array *op_array TSRMLS_DC)
+#endif
 {
 	// nothing to do
 }


### PR DESCRIPTION
The changes fixes the build on PHP 5.5, where zend_execute_ex was introduced to replace zend_execute, which become a function.
