### PR TITLE
fix BRK/CONT jump position

### DIFF
--- a/srm_oparray.c
+++ b/srm_oparray.c
@@ -661,7 +661,7 @@ void vld_dump_op(int nr, zend_op * op_ptr, zend_uint base_address, int notdead, 
 
 		VLD_PRINT(3, " BRK_CONT[ ");
 #if PHP_VERSION_ID >= 50399
-		el = vld_find_brk_cont(op.op2.constant, op.op1.opline_num, opa);
+		el = vld_find_brk_cont(Z_LVAL_P(op.op2.zv), op.op1.opline_num, opa);
 #else
 		el = vld_find_brk_cont(op.op2.u.constant.value.lval, op.op1.u.opline_num, opa);
 #endif
@@ -783,7 +783,7 @@ int vld_find_jump(zend_op_array *opa, unsigned int position, long *jmp1, long *j
 #endif
 		) {
 #if PHP_VERSION_ID >= 50399
-			el = vld_find_brk_cont(opcode.op2.constant, VLD_ZNODE_ELEM(opcode.op1, opline_num), opa);
+			el = vld_find_brk_cont(Z_LVAL_P(opcode.op2.zv), VLD_ZNODE_ELEM(opcode.op1, opline_num), opa);
 #else
 			el = vld_find_brk_cont(opcode.op2.u.constant.value.lval, VLD_ZNODE_ELEM(opcode.op1, opline_num), opa);
 #endif


### PR DESCRIPTION
jump position seems broken of BRK/CONT opcode on php version 5.4 or later.

op2.constant is op_array's literals position and this is overwritten by op2.zv at pass_two.
