### PR TITLE
Get VLD compiling on PHP7-64bit

### DIFF
--- a/php_vld.h
+++ b/php_vld.h
@@ -69,7 +69,7 @@ int vld_printf(FILE *stream, const char* fmt, ...);
 # define ZVAL_VALUE_STRING_TYPE         zend_string
 # define ZVAL_STRING_VALUE(s)           (s.str)->val
 # define ZVAL_STRING_LEN(s)             (s.str)->len
-# define ZSTRING_VALUE(s)               (s)->val
+# define ZSTRING_VALUE(s)               (s ? (s)->val : NULL)
 # define OPARRAY_VAR_NAME(v)            (v)->val
 #else
 # define ZHASHKEYSTR(k) ((k)->arKey)

--- a/set.h
+++ b/set.h
@@ -20,10 +20,10 @@ typedef struct _vld_set {
 } vld_set;
 
 vld_set *vld_set_create(unsigned int size);
-#ifndef ZEND_ENGINE_2
-# define VLD_DEAD_CODE 107
-#else
+#if defined(ZEND_ENGINE_2) || defined(ZEND_ENGINE_3)
 # define VLD_DEAD_CODE 150
+#else
+# define VLD_DEAD_CODE 107
 #endif
 void vld_set_add(vld_set *set, unsigned int position);
 void vld_set_remove(vld_set *set, unsigned int position);

--- a/vld.c
+++ b/vld.c
@@ -264,7 +264,7 @@ static int vld_dump_fe (zend_op_array *fe APPLY_TSRMLS_DC, int num_args, va_list
 	return ZEND_HASH_APPLY_KEEP;
 }
 
-#ifdef ZEND_ENGINE_2
+#if defined(ZEND_ENGINE_2) || defined(ZEND_ENGINE_3)
 static int vld_dump_cle (zend_class_entry **class_entry TSRMLS_DC)
 #else
 static int vld_dump_cle (zend_class_entry *class_entry TSRMLS_DC)
@@ -273,7 +273,7 @@ static int vld_dump_cle (zend_class_entry *class_entry TSRMLS_DC)
 	zend_class_entry *ce;
 	zend_bool have_fe = 0;
 
-#ifdef ZEND_ENGINE_2
+#if defined(ZEND_ENGINE_2) || defined(ZEND_ENGINE_3)
 	ce = *class_entry;
 #else
 	ce = class_entry;


### PR DESCRIPTION
  * Test for either ZEND_ENGINE_2 or ZEND_ENGINE_3, only one is ever set
  * Calculate absolute target opline from relative (jmp_offset / 64bit builds) or absolute (jmp_addr / 32bit builds)
  * Dereference runtime constants from the op_array as needed
  * Comment out references to vld_dump_zval_*() which haven't be implemented