### PR TITLE
Implement remaining PHP7 vld_dump_zval_*() methods

### DIFF
--- a/srm_oparray.c
+++ b/srm_oparray.c
@@ -319,6 +319,30 @@ static inline int vld_dump_zval_constant_array(ZVAL_VALUE_TYPE value)
 }
 #endif
 
+static inline int vld_dump_zval_undef(ZVAL_VALUE_TYPE value)
+{
+	return vld_printf (stderr, "<undef>");
+}
+
+static inline int vld_dump_zval_reference(ZVAL_VALUE_TYPE value)
+{
+	return vld_printf (stderr, "<reference>");
+}
+
+static inline int vld_dump_zval_callable(ZVAL_VALUE_TYPE value)
+{
+	return vld_printf (stderr, "<callable>");
+}
+
+static inline int vld_dump_zval_indirect(ZVAL_VALUE_TYPE value)
+{
+	return vld_printf (stderr, "<indirect>");
+}
+
+static inline int vld_dump_zval_ptr(ZVAL_VALUE_TYPE value)
+{
+	return vld_printf (stderr, "<ptr>");
+}
 
 int vld_dump_zval (zval val)
 {
@@ -341,13 +365,13 @@ int vld_dump_zval (zval val)
 		case IS_CONSTANT_ARRAY: return vld_dump_zval_constant_array (val.value);
 #endif
 #if PHP_VERSION_ID >= 70000
-		/* case IS_UNDEF:          return vld_dump_zval_undef (val.value); */
+		case IS_UNDEF:          return vld_dump_zval_undef (val.value);
 		case IS_FALSE:          return vld_dump_zval_false (val.value);
 		case IS_TRUE:           return vld_dump_zval_true (val.value);
-		/* case IS_REFERENCE:      return vld_dump_zval_reference (val.value); */
-		/* case IS_CALLABLE:       return vld_dump_zval_callable (val.value); */
-		/* case IS_INDIRECT:       return vld_dump_zval_indirect (val.value); */
-		/* case IS_PTR:            return vld_dump_zval_ptr (val.value); */
+		case IS_REFERENCE:      return vld_dump_zval_reference (val.value);
+		case IS_CALLABLE:       return vld_dump_zval_callable (val.value);
+		case IS_INDIRECT:       return vld_dump_zval_indirect (val.value);
+		case IS_PTR:            return vld_dump_zval_ptr (val.value);
 #else
 		case IS_BOOL:           return vld_dump_zval_bool (val.value);
 #endif


### PR DESCRIPTION
Yeah, I probably should have done that in the original commit.
For some reason I was thinking they needed to show data as well,
but I looked again and noticed you're only showing type in these dumpers.