### PR TITLE
Support dumping opcodes of functions/methods on PHP7

### DIFF
--- a/php_vld.h
+++ b/php_vld.h
@@ -73,7 +73,7 @@ int vld_printf(FILE *stream, const char* fmt, ...);
 # define OPARRAY_VAR_NAME(v)            (v)->val
 #else
 # define ZHASHKEYSTR(k) ((k)->arKey)
-# define ZHASHKEYLEN(k) ((k)->nKeyLength)
+# define ZHASHKEYLEN(k) ((k)->nKeyLength - 1)
 # define PHP_URLENCODE_NEW_LEN(v) , &(v)
 
 # define ZVAL_VALUE_TYPE                zvalue_value


### PR DESCRIPTION
I tried VLD on PHP7, then found a bug which we cannot see opcodes in user defined functions.

For example, checking against following code with VLD

```php
<?php
function foo($x, $y) {
    return $x-$y;
}
``` 

VLD shows nothing about `foo()`. This pull request fixes dumping opcodes of functions on PHP7.

