### PR TITLE
Support some new opcodes in PHP 7.2 & 7.3 and fix some opcodes

### DIFF
--- a/srm_oparray.c
+++ b/srm_oparray.c
@@ -272,7 +272,7 @@ static const op_usage opcodes[] = {
 	/*  197 */	{ "ISSET_ISEMPTY_CV", ALL_USED },
 #endif
 #if PHP_VERSION_ID >= 70300
-	/*  198 */  { "FETCH_LIST_W", ALL_USED },
+	/*  198 */	{ "FETCH_LIST_W", ALL_USED },
 #endif
 };
 

--- a/srm_oparray.c
+++ b/srm_oparray.c
@@ -143,9 +143,19 @@ static const op_usage opcodes[] = {
 	/*  95 */	{ "FETCH_UNSET", ALL_USED },
 	/*  96 */	{ "FETCH_DIM_UNSET", ALL_USED },
 	/*  97 */	{ "FETCH_OBJ_UNSET", ALL_USED },
+#if PHP_VERSION_ID >= 70300
+	/*  98 */	{ "FETCH_LIST_R", ALL_USED },
+#else
 	/*  98 */	{ "FETCH_LIST", ALL_USED },
+#endif
 	/*  99 */	{ "FETCH_CONSTANT", ALL_USED },
-	/*  100 */	{ "GOTO", ALL_USED | OP1_OPLINE },
+
+#if PHP_VERSION_ID >= 70300
+	/*  100 */	{ "CHECK_FUNC_ARG", ALL_USED },
+#else
+	/*  100 */	{ "UNKNOWN [100]", ALL_USED },
+#endif
+
 	/*  101 */	{ "EXT_STMT", ALL_USED },
 	/*  102 */	{ "EXT_FCALL_BEGIN", ALL_USED },
 	/*  103 */	{ "EXT_FCALL_END", ALL_USED },
@@ -164,12 +174,14 @@ static const op_usage opcodes[] = {
 
 	/*  116 */	{ "SEND_VAL_EX", ALL_USED },
 	/*  117 */	{ "SEND_VAR", ALL_USED },
-	/*  118 */	{ "INIT_USER_CALL", ALL_USED | EXT_VAL },
 
-	/*  119 */	{ "UNKNOWN [119]", ALL_USED },
 #if PHP_VERSION_ID >= 70000
+	/*  118 */	{ "INIT_USER_CALL", ALL_USED | EXT_VAL },
+	/*  119 */	{ "SEND_ARRAY", ALL_USED },
 	/*  120 */	{ "SEND_USER", ALL_USED },
 #else
+	/*  118 */	{ "UNKNOWN [118]", ALL_USED },
+	/*  119 */	{ "UNKNOWN [119]", ALL_USED },
 	/*  120 */	{ "UNKNOWN [120]", ALL_USED },
 #endif
 
@@ -239,7 +251,11 @@ static const op_usage opcodes[] = {
     /*  182 */ { "BIND_LEXICAL", ALL_USED },
     /*  183 */ { "BIND_STATIC", ALL_USED },
 	/*  184 */	{ "FETCH_THIS", ALL_USED },
+#if PHP_VERSION_ID >= 70300
+	/*  185 */	{ "SEND_FUNC_ARG", ALL_USED },
+#else
 	/*  185 */	{ "UNKNOWN [185]", ALL_USED },
+#endif
 	/*  186 */	{ "ISSET_ISEMPTY_THIS", ALL_USED },
 #endif
 #if PHP_VERSION_ID >= 70200
@@ -252,6 +268,11 @@ static const op_usage opcodes[] = {
 	/*  193 */	{ "GET_TYPE", ALL_USED },
 	/*  194 */	{ "FUNC_NUM_ARGS", ALL_USED },
 	/*  195 */	{ "FUNC_GET_ARGS", ALL_USED },
+	/*  196 */	{ "UNSET_CV", ALL_USED },
+	/*  197 */	{ "ISSET_ISEMPTY_CV", ALL_USED },
+#endif
+#if PHP_VERSION_ID >= 70300
+	/*  198 */  { "FETCH_LIST_W", ALL_USED },
 #endif
 };
 
@@ -552,7 +573,7 @@ void vld_dump_op(int nr, zend_op * op_ptr, unsigned int base_address, int notdea
 
 	if (flags == SPECIAL) {
 		flags = vld_get_special_flags(&op, base_address);
-	} 
+	}
 	if (flags & OP1_OPLINE) {
 		op1_type = VLD_IS_OPLINE;
 	}


### PR DESCRIPTION
OPCode 98: ``FETCH_LIST`` in PHP 7.3 is  ``FETCH_LIST_R``
OPCode 198: implemented in PHP 7.3 as ``FETCH_LIST_W``
See: https://github.com/php/php-src/commit/6d4de4cf0582cf33848826ab78aae58077dc2dea#diff-efb0e85f23f4afcb5ad49a6def5668e9R273

OPCode 119: implemented in PHP 7.0 as ``SEND_ARRAY``
See: https://github.com/php/php-src/commit/de306e70882dd7dd04ea952ef3c665304837c3be#diff-efb0e85f23f4afcb5ad49a6def5668e9R145

OPCode 100: implemented in PHP 7.3 as ``CHECK_FUNC_ARG`` and it never be implemented in PHP >= 5.0 < 7.3
OPCode 185: implemented in PHP 7.3 as ``SEND_FUNC_ARG``
See: https://github.com/php/php-src/commit/3a794d39f081f73b2204aed8b80163a197ab41c3#diff-efb0e85f23f4afcb5ad49a6def5668e9R261

OPCode 196: implemented in PHP 7.2 as ``UNSET_CV``
OPCode 197: implemented in PHP 7.2 as ``ISSET_ISEMPTY_CV``
See: https://github.com/php/php-src/commit/1180d8c8019bf84c1803d65750f1735becbba2a7#diff-efb0e85f23f4afcb5ad49a6def5668e9R270

