### PR TITLE
Replace uint with unsigned

### DIFF
--- a/srm_oparray.c
+++ b/srm_oparray.c
@@ -629,7 +629,7 @@ static const char *get_assign_operation(uint32_t extended_value)
 
 void vld_dump_op(int nr, zend_op * op_ptr, unsigned int base_address, int notdead, int entry, int start, int end, zend_op_array *opa TSRMLS_DC)
 {
-	static uint last_lineno = (uint) -1;
+	static unsigned last_lineno = (unsigned) -1;
 	int print_sep = 0, len;
 	const char *fetch_type = "";
 	unsigned int flags, op1_type, op2_type, res_type;


### PR DESCRIPTION
As of PHP 7.4.0, `uint` is no longer guaranteed to be available on all
platforms.  Therefore we replace it with the portable `unsigned`.