### PR TITLE
constify

### DIFF
--- a/vld.c
+++ b/vld.c
@@ -287,9 +287,9 @@ static zend_op_array *vld_compile_file(zend_file_handle *file_handle, int type)
 {
 	zend_op_array *op_array;
 #if PHP_VERSION_ID < 80100
-	char *filename = file_handle->filename;
+	const char *filename = file_handle->filename;
 #else
-	char *filename = ZSTR_VAL(file_handle->filename);
+	const char *filename = ZSTR_VAL(file_handle->filename);
 #endif
 
 	if (!VLD_G(execute) &&


### PR DESCRIPTION
Sorry, miss that in previous

```
/dev/shm/BUILD/php-pecl-vld-0.17.2/ZTS/vld.c: In function 'vld_compile_file':
/dev/shm/BUILD/php-pecl-vld-0.17.2/ZTS/vld.c:290:26: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  290 |         char *filename = file_handle->filename;
      |                          ^~~~~~~~~~~

```

P.S. obviously not critical, no need for new release